### PR TITLE
Fix cake plugin.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject marginalia "0.5.0"
+(defproject marginalia "0.5.1-SNAPSHOT"
   :description "lightweight literate programming for clojure -- inspired by [docco](http://jashkenas.github.com/docco/)"
   :main marginalia.core
   :eval-in-leiningen true

--- a/src/marginalia/tasks.clj
+++ b/src/marginalia/tasks.clj
@@ -5,11 +5,13 @@
 
    1. In your project.clj, add `[marginalia \"<current version number>\"] to your `:dev-dependencies` and `marginalia.tasks` to `:tasks`
    2. Run `cake marg` from within your project directory."
-  (:use marginalia.core
-        [cake.core :only [deftask]]))
+  (:use cake.core))
 
 (deftask marg
   "Run marginalia against your project code.
    Optionally, you can pass files or directories to control what documentation is generated and in what order."
   {files :marg}
-  (run-marginalia files))
+  (bake
+   (:use marginalia.core) [files files]
+   (binding [marginalia.html/*resources* ""]
+     (run-marginalia files))))


### PR DESCRIPTION
You probably didn't notice it, but the cake plugin was broken in 0.5.0. It couldn't find the resources directory. I fixed it. It's pretty much the same as the Leiningen plugin now. A 0.5.1 bugfix release would be much appreciated. :>
