### PR TITLE
Improved parser substantially!

### DIFF
--- a/src/marginalia/parser.clj
+++ b/src/marginalia/parser.clj
@@ -153,11 +153,25 @@
   [form raw nspace-sym]
   [nil raw nspace-sym])
 
+(defn dispatch-inner-form
+  [form raw nspace-sym]
+  (conj
+   (reduce (fn [[adoc araw] inner-form]
+             (if (seq? inner-form)
+               (let [[d r] (dispatch-form inner-form
+                                          araw
+                                          nspace-sym)]
+                 [(str adoc d) r])
+               [adoc araw]))
+           [nil raw]
+           form)
+   nspace-sym))
+
 (defmethod dispatch-form :default
   [form raw nspace-sym]
   (if (re-find #"^def" (-> form first name))
     (extract-common-docstring form raw nspace-sym)
-    [nil raw nspace-sym]))
+    (dispatch-inner-form form raw nspace-sym)))
 
 (defn extract-docstring [m raw nspace-sym]
   (let [raw (join "\n" (subvec raw (-> m :start dec) (:end m)))


### PR DESCRIPTION
Cleaned-up `extract-common-docstring` and made it ignore forms in which the second item isn't a symbol. That should fix #35, but only by ignoring non-standard def\* forms. 

Then improved `strip-docstring` to remove empty metadata map, like in this example

```
(def ^{:doc "foobar"} foo :bar)
```

And finally (the big one) made `dispatch-form` work recursively as to handle inner forms, like in this code from fnparse:

```
(with-monad parser-m
  (def
    #^{:doc "blah blah blah..."}
    emptiness (m-result nil)))
```

P.S.: That last example make me think about about the Heart Sutra: "form is emptiness; emptiness is form"! ;-)
