### PR TITLE
Improved parser dispatch-form to handle namespace qualified symbol and more...

### DIFF
--- a/src/problem_cases/general.clj
+++ b/src/problem_cases/general.clj
@@ -1,6 +1,6 @@
 (ns problem-cases.general
   "A place to examine poor parser behavior.  These should go in tests when they get written."
-  )
+  (:require [clojure.contrib.types :as t]))
 
 
 ;; Should have only this comment in the left margin.
@@ -152,3 +152,17 @@
   (greater 2 1) => truthy)
 
 '(file->tickets commits)
+
+(t/deftype ::foo foo-t)
+
+(t/deftype ::foo2 foo2-t identity)
+
+(t/deftype ::bar bar-t "normal docstring")
+
+(t/deftype ::bar2 bar2-t "normal docstring" identity)
+
+;; this shouldn't happen in practice!
+
+(t/deftype ::baz baz-t {:doc "docs in attr-map"})
+
+(t/deftype ::baz2 baz2-t {:doc "docs in attr-map"} identity)


### PR DESCRIPTION
Improved parser dispatch-form to handle namespace qualified symbol and added support for contrib version of deftype, fixes #39.

I've change the dispatch function of dispatch-form to look for the first symbol without it's qualifying namespace or ns-alias. Then I modified extract-common-docstring to take an optional 'extractor' argument so that it can handle forms which define a var that isn't the second symbol.

Those changes make it possible to handle case like 'deftype' from the contrib library.
