### PR TITLE
Marginalia fails on clojure files containing strings or other literals outside of forms (top level).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lib
 classes
 out
 webgen.cache
+.lein-failures

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,8 @@
   :dev-dependencies
   [[lein-clojars "0.6.0"]
    [jline "0.9.94"]
+   ;; lein vimclojure& #starts the nailgun server
+   [org.clojars.autre/lein-vimclojure "1.0.0"]
    [swank-clojure "1.2.1"]]
   ;;Needed for testing Latex equation formatting. You must download
   ;;and install MathJax in you doc directory.

--- a/test/parse_test.clj
+++ b/test/parse_test.clj
@@ -1,6 +1,8 @@
 (ns parse-test
   "This module does stuff"
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str])
+  (:use clojure.test)
+  (:require marginalia.parser))
 
 
 ;; It seems that, in Clojure, block
@@ -13,3 +15,9 @@
    Does some other cool stuff too."
   (println (str "Hello World, " name "!")))
 
+(deftest test-inline-literals
+  (is (= (count (marginalia.parser/parse "(ns test)")) 1))
+  ;(is (= (count (marginalia.parser/parse "(ns test)\n123")) 1)) still failing
+  (is (= (count (marginalia.parser/parse "(ns test)\n123\n")) 1))
+  (is (= (count (marginalia.parser/parse "(ns test)\n\"string\"")) 1))
+  (is (= (count (marginalia.parser/parse "(ns test)\n\"some string\"")) 1)))


### PR DESCRIPTION
Fixed errors happening when parser encountered string or number literals outside of forms.

.gitignore: added temporary file generated by `lein test`
project.clj: dependency on vimclojure
test/parse_test.clj: tests for situations causing errors pre-patch
src/marginalia/parser.clj: literal handling during code block merges
