### PR TITLE
Move application stuff out of core.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject marginalia "0.7.0-SNAPSHOT"
   :description "lightweight literate programming for clojure -- inspired by [docco](http://jashkenas.github.com/docco/)"
-  :main marginalia.core
+  :main marginalia.main
   :dependencies
   [[org.clojure/clojure "1.3.0"]
    [org.clojure/tools.namespace "0.1.1"]

--- a/src/marginalia/core.clj
+++ b/src/marginalia/core.clj
@@ -39,8 +39,7 @@
          [parser :only (parse-file)]]
         [clojure.tools
          [namespace :only (read-file-ns-decl)]
-         [cli :only (cli)]])
-  (:gen-class))
+         [cli :only (cli)]]))
 
 
 (def ^{:dynamic true} *test* "src/marginalia/core.clj")
@@ -277,24 +276,3 @@
           (println "Done generating your documentation, please see"
                    (str *docs* "/" file))
           (println ""))))))
-
-(defn -main
-  "The main entry point into Marginalia."
-  [& sources]
-  (binding [marginalia.html/*resources* ""]
-    (run-marginalia sources)))
-
-
-;; # Example Usage
-(comment
-  ;; Command line example
-  (-main "./src/marginalia/core.clj" "./src/marginalia/html.clj")
-
-  ;; This will find all marginalia source files, and then generate an uberdoc.
-  (apply -main (find-clojure-file-paths "./src"))
-
-;; Move these to tests
-  (merge-line {:docstring-text "hello world" :line 3} {:docs ["stuff"]})
-  (merge-line {:code-text "(defn asdf" :line 4} {:docs ["stuff"]})
-  (merge-line {:docs-text "There's only one method in this module", :line 4} {})
-)

--- a/src/marginalia/main.clj
+++ b/src/marginalia/main.clj
@@ -1,0 +1,23 @@
+(ns marginalia.main
+  (:use [marginalia.html :only [*resources*]]
+        [marginalia.core :only [run-marginalia]])
+  (:gen-class))
+
+(defn -main
+  "The main entry point into Marginalia."
+  [& sources]
+  (binding [*resources* ""]
+    (run-marginalia sources)))
+
+;; # Example Usage
+(comment
+  ;; Command line example
+  (-main "./src/marginalia/core.clj" "./src/marginalia/html.clj")
+
+  ;; This will find all marginalia source files, and then generate an uberdoc.
+  (apply -main (find-clojure-file-paths "./src"))
+
+;; Move these to tests
+  (merge-line {:docstring-text "hello world" :line 3} {:docs ["stuff"]})
+  (merge-line {:code-text "(defn asdf" :line 4} {:docs ["stuff"]})
+  (merge-line {:docs-text "There's only one method in this module", :line 4} {}))


### PR DESCRIPTION
This matters because having (:gen-class) in core.clj means that the whole file is AOT'd when really all you want is the actual application code to be compiled. This is a necessity for fixing the Leiningen plugin, since mismatched Clojure versions + AOT'd core.clj = death by NoSuchMethodError.
