### PR TITLE
Comment lines should preserve intermediate whitespace where possible.

### DIFF
--- a/src/marginalia/parser.clj
+++ b/src/marginalia/parser.clj
@@ -247,7 +247,9 @@
     (dispatch-form form raw nspace-sym)))
 
 (defn- ->str [m]
-  (replace (-> m :form .content) #"^;+\s*" ""))
+  (-> (-> m :form .content)
+      (replace #"^;+\s(\s*)" "$1")
+      (replace #"^;+" "")))
 
 (defn merge-comments [f s]
   {:form (Comment. (str (->str f) "\n" (->str s)))


### PR DESCRIPTION
Preserving whitespace allows for indentation-sensitive markdown constructs,
like code block, within comments.

Signed-off-by: Deepak Giridharagopal deepak@puppetlabs.com
