### PR TITLE
Typo in documentation: s/Ouput/Output/

### DIFF
--- a/src/marginalia/core.clj
+++ b/src/marginalia/core.clj
@@ -166,7 +166,7 @@
      :groups groups}))
 
 
-;; ## Ouput Generation
+;; ## Output Generation
 
 (defn filename-contents
   [props output-dir all-files parsed-file]


### PR DESCRIPTION
s/Ouput/Output/
