### PR TITLE
Treat single semicolons on the line as single comments

### DIFF
--- a/src/marginalia/parser.clj
+++ b/src/marginalia/parser.clj
@@ -296,7 +296,7 @@
     (if f
       (cond
        ;; ignore comments with only one semicolon
-       (and (comment? f) (re-find #"^;\s" (-> f :form .content)))
+       (and (comment? f) (re-find #"^;(\s|$)" (-> f :form .content)))
        (recur sections s (first nn) (next nn) nspace)
        ;; merging comments block
        (and (comment? f) (comment? s) (adjacent? f s))


### PR DESCRIPTION
This allows multiline single-semicoloned comments to be treated as a
single comment block and not show them in the output.

The pull request fixes issue #108 I had created earlier.
