### PR TITLE
Add a new option to exclude source files from being processed by Margina...

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Marginalia accepts options as described below:
   * -c --css     Additional css resources `<resource1>;<resource2>;...` (if not given will be taken from `project.clj`)
   * -j --js      Additional javascript resources `<jsfile1>;<jsfile2>;...` (if not given will be taken from `project.clj`)
   * -m --multi   Generate each namespace documentation as a separate file
+  * -e --exclude Exclude source file(s) from the document generation process `<file1>;<file2>;...` (if not given will be taken from `project.clj`)
 
 ### Maven
 
@@ -118,7 +119,8 @@ Marginalia is...
 - [Tero Parviainen](https://github.com/teropa)
 - [MerelyAPseudonym](https://github.com/MerelyAPseudonym)
 - [Ivan](https://github.com/ivantm)
-- [benjamin bader] (https://github.com/benjamin-bader)
+- [benjamin bader](https://github.com/benjamin-bader)
+- [Frederick Giasson](https://github.com/fgiasson)
 
 If I've missed your name then please ping me.
 

--- a/src/marginalia/core.clj
+++ b/src/marginalia/core.clj
@@ -238,6 +238,17 @@
       [(if (= group artifact) artifact (str group "/" artifact))
        version])))
 
+(defn source-excluded?
+  "Check if a source file is excluded from the generated documentation"
+  [source opts]
+  (if-not (empty?
+           (filter #(if (re-find (re-pattern %) source)
+                      true
+                      false)
+                   (-> opts :marginalia :exclude)))
+    true
+    false))
+
 (defn run-marginalia
   "Default generation: given a collection of filepaths in a project, find the .clj
    files at these paths and, if Clojure source files are found:
@@ -249,7 +260,7 @@
 
    If no source files are found, complain with a usage message."
   [args & [project]]
-  (let [[{:keys [dir file name version desc deps css js multi leiningen]} files help]
+  (let [[{:keys [dir file name version desc deps css js multi leiningen exclude]} files help]
         (cli args
              ["-d" "--dir" "Directory into which the documentation will be written" :default "./docs"]
              ["-f" "--file" "File into which the documentation will be written" :default "uberdoc.html"]
@@ -263,7 +274,9 @@
              ["-j" "--js" "Additional javascript resources <resource1>;<resource2>;...
                  If not given will be taken from project.clj"]
              ["-m" "--multi" "Generate each namespace documentation as a separate file" :flag true]
-             ["-l" "--leiningen" "Generate the documentation for a Leiningen project file."])
+             ["-l" "--leiningen" "Generate the documentation for a Leiningen project file."]
+             ["-e" "--exclude" "Exclude source file(s) from the document generation process <resource1>;<resource2>;...
+                 If not given will be taken from project.clj"])
         sources (distinct (format-sources (seq files)))
         sources (if leiningen (cons leiningen sources) sources)]
     (if-not sources
@@ -278,6 +291,7 @@
               marg-opts (merge-with choose
                                     {:css (when css (.split css ";"))
                                      :javascript (when js (.split js ";"))
+                                     :exclude (when exclude (.split exclude ";"))
                                      :leiningen leiningen}
                                     (:marginalia project-clj))
               opts (merge-with choose
@@ -287,7 +301,10 @@
                                 :dependencies (split-deps deps)
                                 :multi multi
                                 :marginalia marg-opts}
-                               project-clj)]
+                               project-clj)
+              sources (->> sources
+                           (filter #(not (source-excluded? % opts)))
+                           (into []))]
           (println "Generating Marginalia documentation for the following source files:")
           (doseq [s sources]
             (println "  " s))

--- a/src/marginalia/core.clj
+++ b/src/marginalia/core.clj
@@ -275,7 +275,7 @@
                  If not given will be taken from project.clj"]
              ["-m" "--multi" "Generate each namespace documentation as a separate file" :flag true]
              ["-l" "--leiningen" "Generate the documentation for a Leiningen project file."]
-             ["-e" "--exclude" "Exclude source file(s) from the document generation process <resource1>;<resource2>;...
+             ["-e" "--exclude" "Exclude source file(s) from the document generation process <file1>;<file2>;...
                  If not given will be taken from project.clj"])
         sources (distinct (format-sources (seq files)))
         sources (if leiningen (cons leiningen sources) sources)]

--- a/src/marginalia/html.clj
+++ b/src/marginalia/html.clj
@@ -131,6 +131,15 @@
 ;; to project.clj. Below is a simple example of both inline and block
 ;; formatted equations.
 ;;
+;; Optionally, you can put the MathJax CDN URL directly as a value of `:javascript`
+;; like this:
+;;
+;;     :marginalia {
+;;       :javascript 
+;;         ["http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"]}
+;;
+;; That way you won't have to download and carry around the MathJax library.
+;;
 ;; When \\(a \ne 0\\), there are two solutions to \\(ax^2 + bx + c = 0\\) and they are
 ;; $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
 


### PR DESCRIPTION
...lia.

The new option is available at the command line with "-e" or "--exclude". It can also be part of the project.clj file via the ":exclude" keyword.

I was requiring this feature because I often have local testing files which I don't want to be included in the documentation.

The new option is quite simple: it simply filter out the files that have been identified by the option out of the "sources" var before it is being used by multidoc! or uberdoc!