### PR TITLE
Addresses an issue where marginalia fails to parse a project.clj where the first form in the file isn't "defproject".

### DIFF
--- a/src/marginalia/core.clj
+++ b/src/marginalia/core.clj
@@ -123,9 +123,13 @@
   ([path]
       (try
         (let [rdr (clojure.lang.LineNumberingPushbackReader.
-                   (java.io.FileReader.
-                    (java.io.File. path)))]
-          (parse-project-form (read rdr)))
+                    (java.io.FileReader.
+                     (java.io.File. path)))]
+          (loop [line (read rdr)]
+            (let [found-project? (= 'defproject (first line))]
+              (if found-project?
+                (parse-project-form line)
+                (recur (read rdr))))))
 	(catch Exception e
           (throw (Exception.
                   (str

--- a/test/marginalia/test/core.clj
+++ b/test/marginalia/test/core.clj
@@ -1,0 +1,6 @@
+(ns marginalia.test.core
+  (:require marginalia.core)
+  (:use clojure.test))
+
+(deftest parse-project-file-simple
+  (is (= "project-name" (:name (marginalia.core/parse-project-file "test/marginalia/test/multi-def-project.clj.txt")))))

--- a/test/marginalia/test/multi-def-project.clj.txt
+++ b/test/marginalia/test/multi-def-project.clj.txt
@@ -1,0 +1,10 @@
+(defn some-other-form
+  []
+  (= 1 1))
+
+(defproject project-name "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.6.0"]])


### PR DESCRIPTION
This addresses #139 

Instead of reading just the first line, parse-project-form will loop
through the full file, stopping when defproject is found and then
parse it as it always has.