### PR TITLE
Remove namespace loading

### DIFF
--- a/src/marginalia/parser.clj
+++ b/src/marginalia/parser.clj
@@ -204,26 +204,22 @@
   (let [sym (second form)]
     (if (symbol? sym)
       (let [maybe-metadocstring (:doc (meta sym))]
-        (do
-          (when (= 'ns (first form))
-            (try (require sym)
-                 (catch Exception _)))
-          (let [nspace (find-ns sym)
-                [maybe-ds remainder] (let [[_ _ ? & more?] form] [? more?])
-                docstring (if (and (string? maybe-ds) remainder)
-                            maybe-ds
-                            (if (= (first form) 'ns)
-                              (if (not maybe-metadocstring)
-                                (when (string? maybe-ds) maybe-ds)
-                                maybe-metadocstring)
-                              (if-let [ds maybe-metadocstring]
-                                ds
-                                (when nspace
-                                  (-> nspace meta :doc)
-                                  (get-var-docstring nspace-sym sym)))))]
-            [docstring
-             (strip-docstring docstring raw)
-             (if (or (= 'ns (first form)) nspace) sym nspace-sym)])))
+        (let [nspace (find-ns sym)
+              [maybe-ds remainder] (let [[_ _ ? & more?] form] [? more?])
+              docstring (if (and (string? maybe-ds) remainder)
+                          maybe-ds
+                          (if (= (first form) 'ns)
+                            (if (not maybe-metadocstring)
+                              (when (string? maybe-ds) maybe-ds)
+                              maybe-metadocstring)
+                            (if-let [ds maybe-metadocstring]
+                              ds
+                              (when nspace
+                                (-> nspace meta :doc)
+                                (get-var-docstring nspace-sym sym)))))]
+          [docstring
+           (strip-docstring docstring raw)
+           (if (or (= 'ns (first form)) nspace) sym nspace-sym)]))
       [nil raw nspace-sym])))
 
 (defn- extract-impl-docstring


### PR DESCRIPTION
Whenever the docstring for a namespace is being determined, the namespace itself is loaded, which may cause side-effects.

This was a problem for me, as I was attempting to document some code that itself required the `overtone.live` namespace of the [Overtone](https://github.com/overtone/overtone) library, which starts up a synthesizer engine whenever the namespace is loaded (which can take a while).

I could not find any documentation as to why the namespace needs to be loaded in order to determine the docstring, and removing it does not seem to affect the rest of the code.

If it is useful to load the namespace in some circumstances, perhaps this PR could be reworked as a configuration option?
