### PR TITLE
Add -X --exclude-lifted-comments option; add tests for inline comment handling

### DIFF
--- a/test/marginalia/test/parse.clj
+++ b/test/marginalia/test/parse.clj
@@ -1,7 +1,7 @@
 (ns marginalia.test.parse
   "This module does stuff"
   (:use clojure.test)
-  (:require marginalia.parser))
+  (:require [marginalia.parser :as p]))
 
 (deftest test-inline-literals
   (is (= (count (marginalia.parser/parse "(ns test)")) 1))
@@ -22,3 +22,141 @@
   (let [{:keys [type docstring]} (first (marginalia.parser/parse simple-fn))]
     (is (= :code type))
     (is (= "the docstring" docstring))))
+
+(deftest inline-comments
+  (testing "inline comments ignored by default"
+    (binding [p/*comments-enabled* (atom true)]
+      (let [result (p/parse
+                     "(ns test)
+
+                     (defn foo
+                       \"docstring\"
+                       []
+                       (let [x 1]
+                         ;; A
+                         x))")]
+        (is (= 2 (count result)))
+        (is (= "docstring" (:docstring (second result))))))
+
+    (binding [p/*comments-enabled* (atom true)]
+      ;; tests that prelude is appended to docstring
+      (let [result (p/parse
+                     "(ns test)
+
+                     ;; A
+                     (defn foo
+                       \"docstring\"
+                       []
+                       (let [x 1]
+                         ;; B
+                         x))")]
+        (is (= 2 (count result)))
+        (is (= "docstring\n\nA" (:docstring (second result)))))))
+
+  (testing "inline comments added to docstring as paragraphs"
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true]
+      (let [result (p/parse
+                     "(ns test)
+
+                     (defn foo
+                       \"docstring\"
+                       []
+                       (let [x 1]
+                         ;; A
+                         x))")]
+        (is (= 3 (count result)))
+        (is (= "docstring\n\n\nA" (:docstring (second result))))))
+
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true]
+      ;; A and B should be separate paragraphs
+      (let [result (p/parse
+                     "(ns test)
+
+                     (defn foo
+                       \"docstring\"
+                       []
+                       ;; A
+                       (let [x 1]
+                         ;; B
+                         x))")]
+        (is (= 3 (count result)))
+        (is (= "docstring\n\n\nA\n\nB" (:docstring (second result)))))))
+
+  (testing "inline comments added to prelude after docstring"
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true]
+      ;; prelude A follows docstring, then B and C as separate paragraphs
+      (let [result (p/parse
+                     "(ns test)
+
+                     ;; A
+                     (defn foo
+                       \"docstring\"
+                       []
+                       ;; B
+                       (let [x 1]
+                         ;; C
+                         x))")]
+        (is (= 3 (count result)))
+        (is (= "docstring\n\nA\n\nB\n\nC" (:docstring (second result))))))
+
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true]
+      ;; this checks that consecutive comment lines stay in the same paragraph
+      (let [result (p/parse
+                     "(ns test)
+
+                     ;; A
+                     (defn foo
+                       \"docstring\"
+                       []
+                       ;; B
+                       ;; C
+                       (let [x 1]
+                         ;; D
+                         x))")]
+        (is (= 3 (count result)))
+        (is (= "docstring\n\nA\n\nB\nC\n\nD" (:docstring (second result))))))
+
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true]
+      ;; this checks that a comment above the function doesn't merge in
+      ;; when separated by a blank line
+      (let [result (p/parse
+                     "(ns test)
+
+                     ;; A
+
+                     (defn foo
+                       \"docstring\"
+                       []
+                       ;; B
+                       ;; C
+                       (let [x 1]
+                         ;; D
+                         x))")]
+        (is (= 4 (count result)))
+        (is (= "A" (:raw (second result))))
+        (is (= "docstring\n\n\nB\nC\n\nD" (:docstring (nth result 2))))))
+
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true]
+      ;; this checks that a comment above the function does merge in
+      ;; when a blank comment joins it to the function
+      (let [result (p/parse
+                     "(ns test)
+
+                     ;; A
+                     ;;
+                     (defn foo
+                       \"docstring\"
+                       []
+                       ;; B
+                       ;; C
+                       (let [x 1]
+                         ;; D
+                         x))")]
+        (is (= 3 (count result)))
+        (is (= "docstring\n\nA\n\n\nB\nC\n\nD" (:docstring (second result))))))))

--- a/test/marginalia/test/parse.clj
+++ b/test/marginalia/test/parse.clj
@@ -36,6 +36,7 @@
                          ;; A
                          x))")]
         (is (= 2 (count result)))
+        (is (re-find #";; A" (:raw (second result))))
         (is (= "docstring" (:docstring (second result))))))
 
     (binding [p/*comments-enabled* (atom true)]
@@ -51,7 +52,24 @@
                          ;; B
                          x))")]
         (is (= 2 (count result)))
+        (is (re-find #";; B" (:raw (second result))))
         (is (= "docstring\n\nA" (:docstring (second result)))))))
+
+  (testing "inline single ; comments still ignored"
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true]
+      (let [result (p/parse
+                     "(ns test)
+
+                     (defn foo
+                       \"docstring\"
+                       []
+                       (let [x 1]
+                         ; A
+                         x))")]
+        (is (= 2 (count result)))
+        (is (re-find #"; A" (:raw (second result))))
+        (is (= "docstring" (:docstring (second result)))))))
 
   (testing "inline comments added to docstring as paragraphs"
     (binding [p/*comments-enabled* (atom true)
@@ -65,8 +83,9 @@
                        (let [x 1]
                          ;; A
                          x))")]
-        (is (= 3 (count result)))
-        (is (= "docstring\n\n\nA" (:docstring (second result))))))
+        (is (= 2 (count result)))
+        (is (re-find #";; A" (:raw (second result))))
+        (is (= "docstring\n\nA" (:docstring (second result))))))
 
     (binding [p/*comments-enabled* (atom true)
               p/*lift-inline-comments* true]
@@ -81,8 +100,10 @@
                        (let [x 1]
                          ;; B
                          x))")]
-        (is (= 3 (count result)))
-        (is (= "docstring\n\n\nA\n\nB" (:docstring (second result)))))))
+        (is (= 2 (count result)))
+        (is (re-find #";; A" (:raw (second result))))
+        (is (re-find #";; B" (:raw (second result))))
+        (is (= "docstring\n\nA\n\nB" (:docstring (second result)))))))
 
   (testing "inline comments added to prelude after docstring"
     (binding [p/*comments-enabled* (atom true)
@@ -99,7 +120,10 @@
                        (let [x 1]
                          ;; C
                          x))")]
-        (is (= 3 (count result)))
+        (is (= 2 (count result)))
+        (is (not (re-find #";; A" (:raw (second result)))))
+        (is (re-find #";; B" (:raw (second result))))
+        (is (re-find #";; C" (:raw (second result))))
         (is (= "docstring\n\nA\n\nB\n\nC" (:docstring (second result))))))
 
     (binding [p/*comments-enabled* (atom true)
@@ -117,7 +141,10 @@
                        (let [x 1]
                          ;; D
                          x))")]
-        (is (= 3 (count result)))
+        (is (= 2 (count result)))
+        (is (re-find #";; B" (:raw (second result))))
+        (is (re-find #";; C" (:raw (second result))))
+        (is (re-find #";; D" (:raw (second result))))
         (is (= "docstring\n\nA\n\nB\nC\n\nD" (:docstring (second result))))))
 
     (binding [p/*comments-enabled* (atom true)
@@ -137,8 +164,11 @@
                        (let [x 1]
                          ;; D
                          x))")]
-        (is (= 4 (count result)))
+        (is (= 3 (count result)))
         (is (= "A" (:raw (second result))))
+        (is (re-find #";; B" (:raw (nth result 2))))
+        (is (re-find #";; C" (:raw (nth result 2))))
+        (is (re-find #";; D" (:raw (nth result 2))))
         (is (= "docstring\n\n\nB\nC\n\nD" (:docstring (nth result 2))))))
 
     (binding [p/*comments-enabled* (atom true)
@@ -158,5 +188,140 @@
                        (let [x 1]
                          ;; D
                          x))")]
+        (is (= 2 (count result)))
+        (is (not (re-find #";; A" (:raw (second result)))))
+        (is (re-find #";; B" (:raw (second result))))
+        (is (re-find #";; C" (:raw (second result))))
+        (is (re-find #";; D" (:raw (second result))))
+        (is (= "docstring\n\nA\n\n\nB\nC\n\nD" (:docstring (second result))))))))
+
+(deftest inline-comments-deleted
+  (testing "inline comments added to docstring as paragraphs and deleted"
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true
+              p/*delete-lifted-comments* true]
+      (let [result (p/parse
+                     "(ns test)
+
+                     (defn foo
+                       \"docstring\"
+                       []
+                       (let [x 1]
+                         ;; A
+                         x))")]
+        (is (= 2 (count result)))
+        (is (not (re-find #";; A" (:raw (second result)))))
+        (is (= "docstring\n\nA" (:docstring (second result))))))
+
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true
+              p/*delete-lifted-comments* true]
+      ;; A and B should be separate paragraphs
+      (let [result (p/parse
+                     "(ns test)
+
+                     (defn foo
+                       \"docstring\"
+                       []
+                       ;; A
+                       (let [x 1]
+                         ;; B
+                         x))")]
+        (is (= 2 (count result)))
+        (is (not (re-find #";; A" (:raw (second result)))))
+        (is (not (re-find #";; B" (:raw (second result)))))
+        (is (= "docstring\n\nA\n\nB" (:docstring (second result)))))))
+
+  (testing "inline comments added to prelude after docstring"
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true
+              p/*delete-lifted-comments* true]
+      ;; prelude A follows docstring, then B and C as separate paragraphs
+      (let [result (p/parse
+                     "(ns test)
+
+                     ;; A
+                     (defn foo
+                       \"docstring\"
+                       []
+                       ;; B
+                       (let [x 1]
+                         ;; C
+                         x))")]
+        (is (= 2 (count result)))
+        (is (not (re-find #";; A" (:raw (second result)))))
+        (is (not (re-find #";; B" (:raw (second result)))))
+        (is (not (re-find #";; C" (:raw (second result)))))
+        (is (= "docstring\n\nA\n\nB\n\nC" (:docstring (second result))))))
+
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true
+              p/*delete-lifted-comments* true]
+      ;; this checks that consecutive comment lines stay in the same paragraph
+      (let [result (p/parse
+                     "(ns test)
+
+                     ;; A
+                     (defn foo
+                       \"docstring\"
+                       []
+                       ;; B
+                       ;; C
+                       (let [x 1]
+                         ;; D
+                         x))")]
+        (is (= 2 (count result)))
+        (is (not (re-find #";; B" (:raw (second result)))))
+        (is (not (re-find #";; C" (:raw (second result)))))
+        (is (not (re-find #";; D" (:raw (second result)))))
+        (is (= "docstring\n\nA\n\nB\nC\n\nD" (:docstring (second result))))))
+
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true
+              p/*delete-lifted-comments* true]
+      ;; this checks that a comment above the function doesn't merge in
+      ;; when separated by a blank line
+      (let [result (p/parse
+                     "(ns test)
+
+                     ;; A
+
+                     (defn foo
+                       \"docstring\"
+                       []
+                       ;; B
+                       ;; C
+                       (let [x 1]
+                         ;; D
+                         x))")]
         (is (= 3 (count result)))
+        (is (= "A" (:raw (second result))))
+        (is (not (re-find #";; B" (:raw (nth result 2)))))
+        (is (not (re-find #";; C" (:raw (nth result 2)))))
+        (is (not (re-find #";; D" (:raw (nth result 2)))))
+        (is (= "docstring\n\n\nB\nC\n\nD" (:docstring (nth result 2))))))
+
+    (binding [p/*comments-enabled* (atom true)
+              p/*lift-inline-comments* true
+              p/*delete-lifted-comments* true]
+      ;; this checks that a comment above the function does merge in
+      ;; when a blank comment joins it to the function
+      (let [result (p/parse
+                     "(ns test)
+
+                     ;; A
+                     ;;
+                     (defn foo
+                       \"docstring\"
+                       []
+                       ;; B
+                       ;; C
+                       (let [x 1]
+                         ;; D
+                         x))")]
+        (is (= 2 (count result)))
+        (is (not (re-find #";; A" (:raw (second result)))))
+        (is (not (re-find #";; B" (:raw (second result)))))
+        (is (not (re-find #";; C" (:raw (second result)))))
+        (is (not (re-find #";; D" (:raw (second result)))))
         (is (= "docstring\n\nA\n\n\nB\nC\n\nD" (:docstring (second result))))))))


### PR DESCRIPTION
This adds tests for how the parser handles inline comments by default, with the recently merged -L option, and also with the new -X modifier option.

It also fixes a bug with ; inline comments in the last PR I submitted.