### PR TITLE
Naive solution to #81

### DIFF
--- a/src/marginalia/parser.clj
+++ b/src/marginalia/parser.clj
@@ -251,7 +251,11 @@
                               (when nspace
                                 (-> nspace meta :doc)
                                 (get-var-docstring nspace-sym sym)))))]
-          [docstring
+          [(when docstring
+             ;; Exclude flush left docstrings from adjustment:
+             (if (re-find #"\n[^\s]" docstring)
+               docstring
+               (replace docstring #"\n  " "\n")))
            (strip-docstring docstring raw)
            (if (or (= 'ns (first form)) nspace) sym nspace-sym)]))
       [nil raw nspace-sym])))


### PR DESCRIPTION
This works for docstrings that are flush left or indented two spaces, which should be the two common cases. The naivety is in assuming that a newline followed by a non-whitespace character indicates flush left, and also that it is safe to just strip the first two spaces off each line of the docstring. It's as safe as some of the other text manipulation Marginalia does :)

Caveat: If a docstring is indented three spaces (per example 2 in my comment on #81) then they'll be unaffected by this change (and they'll still get the weird formatting they got before!).