### PR TITLE
fix sorting in (find-processable-file-paths)

### DIFF
--- a/src/marginalia/core.clj
+++ b/src/marginalia/core.clj
@@ -95,7 +95,7 @@
   (->> (io/file dir)
        (file-seq)
        (filter (partial processable-file? pred))
-       (sort-by parse-ns second)
+       (sort-by parse-ns)
        (map #(.getCanonicalPath %))))
 
 ;; ## Project Info Parsing

--- a/src/marginalia/core.clj
+++ b/src/marginalia/core.clj
@@ -95,7 +95,7 @@
   (->> (io/file dir)
        (file-seq)
        (filter (partial processable-file? pred))
-       (sort-by #(->> % parse-ns second))
+       (sort-by parse-ns second)
        (map #(.getCanonicalPath %))))
 
 ;; ## Project Info Parsing


### PR DESCRIPTION
The `(parse-ns)` function always returns a string,
so this code:
    `(sort-by #(->> % parse-ns second))`
actually sorts by the second character of the string.

Seems like this `(second)` call is a rudiment from the past.
And this commit removes it, and thus fixes the sorting.