### PR TITLE
Issue 176: Add support for :extend-via-metadata in defprotocol

### DIFF
--- a/test/marginalia/test/parse.clj
+++ b/test/marginalia/test/parse.clj
@@ -11,6 +11,8 @@
   (is (= (count (marginalia.parser/parse "(ns test)\n\"some string\"")) 1))
   (is (= (count (marginalia.parser/parse "(ns test (:require [marginalia.parser :as parser]))\n(defn foo [] ::parser/foo)")) 1)))
 
+(deftest extend-via-metadata
+  (is (marginalia.parser/parse "(ns test)\n(defprotocol Foo \"Does a Foo\" :extend-via-metadata true (do-foo! [_ opts] \"Foo!\"))")))
 
 (def simple-fn
   "(defn some-fn


### PR DESCRIPTION
A solution for the problem mentioned in https://github.com/gdeer81/marginalia/issues/176 - that Clojure 1.10 added support for options in the `defprotocol` macro https://clojure.org/reference/protocols#_extend_via_metadata. Currently, the supported options are limited to `:extend-via-metadata`, which adds two forms before the actual method definitions.

This PR checks to see if the `:extend-via-metadata` key is present in the `defprotocol` body, and accounts for its presence or absence.

