### PR TITLE
Handle schema annotations after function names

### DIFF
--- a/src/marginalia/parser.clj
+++ b/src/marginalia/parser.clj
@@ -265,7 +265,10 @@
     (if (symbol? sym)
       (let [maybe-metadocstring  (:doc (meta sym))
             nspace               (find-ns sym)
-            [maybe-ds remainder] (let [[_ _ ? & more?] form] [? more?])
+            [maybe-ds remainder] (let [[_ _ ? & more?] form]
+                                      (if (= :- ?)
+                                        [(second more?) (nnext more?)]
+                                        [? more?]))
             docstring            (if (and (string? maybe-ds) remainder)
                                    maybe-ds
                                    (if (= (first form) 'ns)

--- a/test/marginalia/parse_test.clj
+++ b/test/marginalia/parse_test.clj
@@ -26,6 +26,38 @@
     (is (= :code the-type))
     (is (= "the docstring" docstring))))
 
+(def schema-return-type-fn
+  "(defn some-fn :- :string
+  \"the docstring\"
+  [x]
+  (str x))")
+
+(def schema-return-type-qualified-fn
+  "(defn some-fn :- ::output/schema
+  \"the docstring\"
+  [x]
+  (str x))")
+
+(def schema-return-type-vector-fn
+  "(defn some-fn :- [:maybe :int]
+  \"the docstring\"
+  [x]
+  (str x))")
+
+(deftest test-parse-schema-return-type-docstring
+  (testing "simple keyword return type"
+    (let [{docstring :docstring the-type :type} (first (marginalia.parser/parse schema-return-type-fn))]
+      (is (= :code the-type))
+      (is (= "the docstring" docstring))))
+  (testing "qualified keyword return type"
+    (let [{docstring :docstring the-type :type} (first (marginalia.parser/parse schema-return-type-qualified-fn))]
+      (is (= :code the-type))
+      (is (= "the docstring" docstring))))
+  (testing "vector return type"
+    (let [{docstring :docstring the-type :type} (first (marginalia.parser/parse schema-return-type-vector-fn))]
+      (is (= :code the-type))
+      (is (= "the docstring" docstring)))))
+
 (def reader-conditional-fn
   "(defn error
   \"Returns a language-appropriate error\"


### PR DESCRIPTION
Fixes #133.

Both Plumatic Schema and Malli can annotate functions with a return schema using syntax like `(def fn-name :- Type "docstring" ...)`.

Marginalia previously did not recognize those docstrings, therefore they were not extracted to the left-hand prose document, nor removed from the right-hand view of the code.

This PR checks for the `:-` marker that both schema libraries use, and skips over it to locate and extract the docstring correctly. The `:- Type` is preserved in the code view.

There are some test cases in the repo, plus I checked it against some [Metabase code](https://github.com/metabase/metabase/blob/master/src/metabase/lib/aggregation.cljc#L43-L47) that uses Malli-powered `mu/defn` and it works beautifully.