### PR TITLE
Fix permissions error on CI

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -47,4 +47,8 @@
  :config-in-ns
  {tests
   {:linters
-   {:missing-docstring {:level :off}}}}}
+   {:missing-docstring {:level :off}}}}
+
+  :output
+ {:exclude-files
+  ["^test/marginalia/resources"]}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
   kondo:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      checks: write
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: DeLaGuardo/clojure-lint-action@master


### PR DESCRIPTION
The Kondo job started to fail with:

```
Error Error: Received status code 403
    at IncomingMessage.res.on (/action/lib/request.js:13:39)
    at IncomingMessage.emit (events.js:203:15)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/checks/runs#create-a-check-run","status":"403"}
```