### PR TITLE
Parse docstrings, general clean up

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,27 +21,14 @@ jobs:
     - name: Setup Clojure
       uses: DeLaGuardo/setup-clojure@12.3
       with:
-        lein: 2.11.1
+        lein: 2.12.0
+        clj-kondo: 2026.04.15
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.5
       with:
         path: ~/.m2/repository
         key: "m2-${{ hashFiles('project.clj') }}"
+    - name: "Lint with clj-kondo"
+      run: clj-kondo --lint src/marginalia test
     - name: Run tests
       run: lein test
-  kondo:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      checks: write
-    steps:
-    - uses: actions/checkout@v4.1.0
-    - uses: DeLaGuardo/clojure-lint-action@master
-      with:
-        check-name: Run clj-kondo
-        clj-kondo-args: >-
-          --lint
-          src/marginalia
-          test
-        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .cpcache
 .lein-deps-sum
 .lein-failures
+.lein-repl-history
 .nrepl-port
 /.calva/output-window/
 /.clj-kondo/.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGES
 
+Unreleased
+* Switch markdown parsers to [flexmark-java](https://github.com/vsch/flexmark-java) to address [#199](https://github.com/clj-commons/marginalia/issues/199).
+* Support docstrings in `defmethod`.
+* Clean up the parsing tests.
+* Remove non-functioning css for `<tr>`.
+* Clean up `source-excluded` to do less work.
+* Update tools.cli to 1.4.256.
+* Update tools.namespace to 1.5.1.
+
 0.9.2 -- 01-31-2024
 * Add `:meta` support to address [#186](https://github.com/clj-commons/marginalia/issues/186).
 * Update all dependencies.

--- a/project.clj
+++ b/project.clj
@@ -8,9 +8,9 @@
   :dependencies
   [[org.clojure/clojure "1.11.1"]
    [org.clojure/clojurescript "1.11.132"]
-   [org.clojure/tools.namespace "1.4.5"]
-   [org.clojure/tools.cli "1.0.219"]
-   [org.markdownj/markdownj-core "0.4"]
+   [org.clojure/tools.namespace "1.5.1"]
+   [org.clojure/tools.cli "1.4.256"]
+   [com.vladsch.flexmark/flexmark-all "0.64.8"]
    [de.ubercode.clostache/clostache "1.4.0"]]
 
   :resource-paths ["vendor"]

--- a/src/marginalia/core.clj
+++ b/src/marginalia/core.clj
@@ -107,11 +107,13 @@
 (defn parse-project-form
   "Parses a project.clj file and returns a map in the following form
 
-       {:name
-        :version
-        :dependencies
-        :dev-dependencies
-        etc...}
+  ```clojure
+  {:name
+   :version
+   :dependencies
+   :dev-dependencies
+   etc...}
+  ```
   by merging into the name and version information the rest of the defproject
   forms (`:dependencies`, etc)"
   [[_ project-name version-number & attributes]]
@@ -120,7 +122,7 @@
 	 (apply hash-map attributes)))
 
 (defn parse-project-file
-  "Parses a project file -- './project.clj' by default -- and returns a map
+  "Parses a project file -- `./project.clj` by default -- and returns a map
    assembled according to the logic in parse-project-form."
   ([] (parse-project-file "./project.clj"))
   ([path]
@@ -175,7 +177,7 @@
         pages        (map #(filename-contents props output-dir parsed-files %) parsed-files)]
     (doseq [f (conj pages {:name     (io/file output-dir "toc.html")
                            :contents index})]
-           (spit (:name f) (:contents f)))))
+      (spit (:name f) (:contents f)))))
 
 (defn uberdoc!
   "Generates an uberdoc html file from 3 pieces of information:
@@ -183,8 +185,8 @@
    2. The path to spit the result (`output-file-name`)
    1. Results from processing source files (`path-to-doc`)
    3. Project metadata as a map, containing at a minimum the following:
-     - :name
-     - :version"
+     - `:name`
+     - `:version`"
   [output-file-name files-to-analyze props]
   (let [source (html/uberdoc-html
                 props
@@ -220,13 +222,9 @@
 (defn source-excluded?
   "Check if a source file is excluded from the generated documentation"
   [source opts]
-  (if-not (empty?
-           (filter #(if (re-find (re-pattern %) source)
-                      true
-                      false)
-                   (-> opts :marginalia :exclude)))
-    true
-    false))
+  (boolean
+   (seq (filter #(re-find (re-pattern %) source)
+                (-> opts :marginalia :exclude)))))
 
 (def ^:private cli-flags
   ;; If these are modified, update the README and the `select-keys` allowlist in `resolved-opts+sources` as well
@@ -308,7 +306,7 @@
                                          ;; project.clj has the lowest priority
                                          project-clj)
             included-sources (->> sources
-                                  (filter #(not (source-excluded? % opts)))
+                                  (remove #(source-excluded? % opts))
                                   (into []))]
         [opts included-sources]))))
 

--- a/src/marginalia/html.clj
+++ b/src/marginalia/html.clj
@@ -1,9 +1,12 @@
 (ns marginalia.html
   "Utilities for converting parse results into html."
   (:require
+   [clojure.java.io :as io]
    [marginalia.hiccup :as hiccup :refer [html]])
   (:import
-   [com.petebevin.markdown MarkdownProcessor]))
+   (com.vladsch.flexmark.html HtmlRenderer)
+   (com.vladsch.flexmark.parser Parser)
+   [com.vladsch.flexmark.util.data MutableDataSet]))
 
 (set! *warn-on-reflection* true)
 
@@ -18,9 +21,10 @@
 (defn css
   "Quick and dirty dsl for inline css rules, similar to hiccup.
 
-   ex. `(css [:h1 {:color \"blue\"}] [:div.content p {:text-indent \"1em\"}])`
-
-   -> `h1 {color: blue;} div.content p {text-indent: 1em;}`"
+   ```clojure
+  (css [:h1 {:color \"blue\"}] [:div.content p {:text-indent \"1em\"}])
+  ;; => h1 {color: blue;} div.content p {text-indent: 1em;}
+  ```"
   [& rules]
   (html [:style {:type "text/css"}
          (apply str (map css-rule rules))]))
@@ -29,19 +33,13 @@
   "Stolen from leiningen"
   [resource-name]
   (try
-    (-> (.getContextClassLoader (Thread/currentThread))
-        (.getResourceAsStream resource-name)
-        (java.io.InputStreamReader.)
-        (slurp))
+    (slurp (io/resource resource-name))
     (catch java.lang.NullPointerException _
       (println (str "Could not locate resources at " resource-name))
       (println "    ... attempting to fix.")
       (let [resource-name (str *resources* resource-name)]
         (try
-          (-> (.getContextClassLoader (Thread/currentThread))
-              (.getResourceAsStream resource-name)
-              (java.io.InputStreamReader.)
-              (slurp))
+          (slurp (io/resource resource-name))
           (catch java.lang.NullPointerException _
             (println (str "    STILL could not locate resources at " resource-name ". Giving up!"))))))))
 
@@ -59,42 +57,48 @@
 ;; The following functions handle preparation of doc text (both comment and docstring
 ;; based) for display through html & css.
 
-;; Markdown processor.
-(def ^:private ^MarkdownProcessor mdp (MarkdownProcessor.))
+;; Two parsing options for the markdown processor are set:
+;; * If a numbered list doesn't start at 1, ignore all numbers and start at 1
+;; * If a numbered list has an entry with a dash or * instead, treat it as a sublist
+(def ^:private ^MutableDataSet format-opts
+  (doto (MutableDataSet.)
+    (.set Parser/LISTS_ORDERED_LIST_MANUAL_START false)
+    (.set Parser/LISTS_ITEM_TYPE_MISMATCH_TO_SUB_LIST true)))
+(def ^:private ^Parser parser (.build (Parser/builder format-opts)))
+(def ^:private ^HtmlRenderer renderer (.build (HtmlRenderer/builder format-opts)))
 
 (defn md
-  "Markdown string to html converter. Translates strings like:
+  "Markdown string to html converter.
 
-   \"# header!\" -> `\"<h1>header!</h1>\"`
+  ```clojure
+  (md \"# header!\")
+  ;; => \"<h1>header!</h1>\"
 
-   \"## header!\" -> `\"<h2>header!</h2>\"`
-
-   ..."
+  (md \"## header!\")
+  ;; => \"<h2>header!</h2>\"
+  ```"
   [^String s]
-  (.markdown mdp s))
+  (->> s
+       (.parse parser)
+       (.render renderer)))
 
-;; As a result of docifying then grouping, you'll end up with a seq like this one:
-;; <pre><code>[...
-;; {:docs [{:docs-text "Some doc text"}]
-;;  :codes [{:code-text "(def something \"hi\")"}]}
-;; ...]</code></pre>
-;;
-;; `docs-to-html` and `codes-to-html` convert their respective entries into html,
-;; and `group-to-html` calls them on each seq item to do so.
+;; `docs-to-html` and `codes-to-html` convert their respective entries into html..
 
 (defn docs-to-html
-  "Converts a docs section to html by threading each doc line through the forms
-   outlined above.
+  "Parse a string (docstring) as Markdown and then render it as html.
 
-   ex. (docs-to-html [{:doc-text \"# hello world!\"} {:docstring-text \"I'm a docstring!}])
-
-   ->  `\"<h1>hello world!</h1><br />\"`"
+  ```clojure
+  (docs-to-html \"# hello world!\")
+  ;; => \"<h1>hello world!</h1>\n\"
+  ```"
   [docs]
   (-> docs
       str
       (md)))
 
-(defn- codes-to-html [code-block]
+(defn codes-to-html
+  "Render a code-block to html."
+  [code-block]
   (html [:pre {:class "brush: clojure"}
          (hiccup/escape-html code-block)]))
 
@@ -142,7 +146,9 @@
 ;; [MathJax](http://www.mathjax.org/) Javascript library to the docs
 ;; directory and then add
 ;;
-;;     :marginalia {:javascript ["mathjax/MathJax.js"]}
+;; ```clojure
+;; :marginalia {:javascript ["mathjax/MathJax.js"]}
+;; ```
 ;;
 ;; to project.clj. :javascript and :css accept a vector of paths or URLs
 ;;
@@ -151,9 +157,10 @@
 ;; Optionally, you can put the MathJax CDN URL directly as a value of `:javascript`
 ;; like this:
 ;;
-;;     :marginalia {
-;;       :javascript
-;;         ["http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"]}
+;; ```clojure
+;; :marginalia
+;; {:javascript
+;;  ["http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"]}
 ;;
 ;; That way you won't have to download and carry around the MathJax library.
 ;;
@@ -168,7 +175,7 @@
            (when-let [js (:javascript options)]
              (map #(vector :script {:type "text/javascript" :src %}) js))
            (when-let [the-css (:css options)]
-             (map #(vector :link {:tyle "text/css" :rel "stylesheet" :href %}) the-css))))))
+             (map #(vector :link {:style "text/css" :rel "stylesheet" :href %}) the-css))))))
 
 ;; Is &lt;h1/&gt; overloaded?  Maybe we should consider redistributing
 ;; header numbers instead of adding classes to all the h1 tags.
@@ -337,8 +344,6 @@
             :margin-bottom "10px"}]
    [:code {:display "inline"}]
    [:p {:margin-top "8px"}]
-   [:tr {:margin "0px"
-         :padding "0px"}]
    [:td.docs {:width "410px"
               :max-width "410px"
               :vertical-align "top"
@@ -348,7 +353,7 @@
               :border "none"
               :background-color "#FFF"}]
    [:td.docs :pre {:font-size "12px"
-                   :overflow "hidden"}]
+                   :overflow "auto"}]
    [:td.codes {:width "55%"
                :background-color "#F5F5FF"
                :vertical-align "top"
@@ -359,7 +364,7 @@
                :font-size "10pt"
                :border-left "solid #E5E5EE 1px"}]
    [:td.spacer {:padding-bottom "40px"}]
-   [:pre :code {:display "block"
+   [:pre :code {:display "inline-block"
                 :padding "4px"}]
    [:code {:background-color "ghostWhite"
            :border "solid #DEDEDE 1px"
@@ -437,7 +442,8 @@
    (header-html project-metadata)
    (toc-html {:uberdoc? false} docs)
    ""   ;; no contents
-   "")) ;; no floating toc
+   ""   ;; no floating toc
+   ,)) 
 
 (defn single-page-html
   "Generate a given page's HTML"
@@ -449,4 +455,4 @@
    "" ;; no toc
    (groups-html {:uberdoc? false} doc)
    "" ;; no floating toc
-   ))
+   ,))

--- a/src/marginalia/parser.clj
+++ b/src/marginalia/parser.clj
@@ -6,7 +6,7 @@
   (:require
    [cljs.tagged-literals :as cljs]
    [clojure.string :as str]
-   [clojure.tools.namespace :as tools.ns])
+   [clojure.tools.namespace.file :as tools.ns])
   (:import
    [clojure.lang LineNumberingPushbackReader LispReader]
    [java.io File Reader Writer]))
@@ -339,8 +339,8 @@
   (extract-common-docstring form raw nspace-sym))
 
 (defmethod dispatch-form 'defmethod
-  [_form raw nspace-sym]
-  [nil raw nspace-sym])
+  [form raw nspace-sym]
+  (extract-common-docstring form raw nspace-sym))
 
 (defn- dispatch-inner-form
   [form raw nspace-sym]

--- a/src/problem_cases/general.clj
+++ b/src/problem_cases/general.clj
@@ -47,14 +47,15 @@
   "This is a defmulti docstring, it should also be on the left"
   class)
 
-(defmethod bazfoo String [s]
-  "This is a defmethod docstring.  It should be on the left."
+(defmethod bazfoo
+  "This is a defmethod docstring. It should be on the left."
+  String [s]
   (vec (seq s)))
 
 (bazfoo "abc")
 
 (defprotocol Foo
-  "This is a protocol docstring.  It should be on the left."
+  "This is a protocol docstring. It should be on the left."
   (lookup  [cache e])
   (has?    [cache e] )
   (hit     [cache e])

--- a/test/marginalia/html_test.clj
+++ b/test/marginalia/html_test.clj
@@ -1,0 +1,20 @@
+(ns marginalia.html-test
+  (:require
+   [clojure.test :refer :all]
+   [marginalia.html :as html]
+   [marginalia.parser :as p]))
+
+(def markdown-docstring-fn
+  "(defn some-fn
+  \"the docstring
+
+  ```clojure
+  (some-fn 1 :abc #{['foo \\\"bar\\\"]})
+  ```\"
+  [& args]
+  (vec args))")
+
+(deftest markdown-docstring-test
+  (is (=
+       "<p>the docstring</p>\n<pre><code class=\"language-clojure\">(some-fn 1 :abc #{['foo &quot;bar&quot;]})\n</code></pre>\n"
+       (html/docs-to-html (:docstring (first (p/parse markdown-docstring-fn)))))))

--- a/test/marginalia/parse_test.clj
+++ b/test/marginalia/parse_test.clj
@@ -5,26 +5,47 @@
    [marginalia.parser :as p]))
 
 (deftest test-inline-literals
-  (is (= (count (marginalia.parser/parse "(ns test)")) 1))
-  (is (= (count (marginalia.parser/parse "(ns test)\n123")) 1))
-  (is (= (count (marginalia.parser/parse "(ns test)\n123\n")) 1))
-  (is (= (count (marginalia.parser/parse "(ns test)\n\"string\"")) 1))
-  (is (= (count (marginalia.parser/parse "(ns test)\n\"some string\"")) 1))
-  (is (= (count (marginalia.parser/parse "(ns test (:require [marginalia.parser :as parser]))\n(defn foo [] ::parser/foo)")) 1)))
+  (is (= 1 (count (p/parse "(ns test)"))))
+  (is (= 1 (count (p/parse "(ns test)\n123"))))
+  (is (= 1 (count (p/parse "(ns test)\n123\n"))))
+  (is (= 1 (count (p/parse "(ns test)\n\"string\""))))
+  (is (= 1 (count (p/parse "(ns test)\n\"some string\""))))
+  (is (= 1 (count (p/parse "(ns test (:require [marginalia.parser :as parser]))\n(defn foo [] ::parser/foo)")))))
 
-(deftest extend-via-metadata
-  (is (marginalia.parser/parse "(ns test)\n(defprotocol Foo \"Does a Foo\" :extend-via-metadata true (do-foo! [_ opts] \"Foo!\"))")))
+(def def-docstring
+  "(def PI \"a docstring\" 3.1415926)")
 
-(def simple-fn
+(def defn-docstring
   "(defn some-fn
   \"the docstring\"
   [x]
   (* x x))")
 
-(deftest test-parse-fn-docstring
-  (let [{docstring :docstring the-type :type} (first (marginalia.parser/parse simple-fn))]
-    (is (= :code the-type))
-    (is (= "the docstring" docstring))))
+(def markdown-docstring-fn
+  "(defn some-fn
+  \"the docstring
+
+  ```clojure
+  (some-fn 1 :abc #{['foo \\\"bar\\\"]})
+  ```\"
+  [& args]
+  (vec args))")
+
+(def defmulti-docstring
+  "(defmulti bazfoo
+  \"This is a defmulti docstring\"
+  class)")
+
+(def defmethod-docstring
+  "(defmethod bazfoo
+  \"This is a defmethod docstring\"
+  String [s]
+  (vec (seq s)))")
+
+(def defprotocol-docstring
+  "(defprotocol Foo \"Does a Foo\"
+    :extend-via-metadata true
+    (do-foo! [_ opts] \"Foo!\"))")
 
 (def schema-return-type-fn
   "(defn some-fn :- :string
@@ -44,20 +65,6 @@
   [x]
   (str x))")
 
-(deftest test-parse-schema-return-type-docstring
-  (testing "simple keyword return type"
-    (let [{docstring :docstring the-type :type} (first (marginalia.parser/parse schema-return-type-fn))]
-      (is (= :code the-type))
-      (is (= "the docstring" docstring))))
-  (testing "qualified keyword return type"
-    (let [{docstring :docstring the-type :type} (first (marginalia.parser/parse schema-return-type-qualified-fn))]
-      (is (= :code the-type))
-      (is (= "the docstring" docstring))))
-  (testing "vector return type"
-    (let [{docstring :docstring the-type :type} (first (marginalia.parser/parse schema-return-type-vector-fn))]
-      (is (= :code the-type))
-      (is (= "the docstring" docstring)))))
-
 (def reader-conditional-fn
   "(defn error
   \"Returns a language-appropriate error\"
@@ -65,10 +72,21 @@
   #?(:clj  (Exception. msg)
      :cljs (js/Error. msg)))")
 
-(deftest test-reader-conditional
-  (let [{docstring :docstring the-type :type} (first (marginalia.parser/parse reader-conditional-fn))]
-    (is (= :code the-type))
-    (is (= "Returns a language-appropriate error" docstring))))
+(deftest test-parse-fn-docstring
+  (are [input expected] (let [{docstring :docstring the-type :type} (first (p/parse input))]
+                          (is (= :code the-type))
+                          (is (= expected docstring))
+                          true)
+    def-docstring "a docstring"
+    defn-docstring "the docstring"
+    markdown-docstring-fn "the docstring\n\n```clojure\n(some-fn 1 :abc #{['foo \"bar\"]})\n```"
+    defmulti-docstring "This is a defmulti docstring"
+    defmethod-docstring "This is a defmethod docstring"
+    defprotocol-docstring "Does a Foo"
+    schema-return-type-fn "the docstring"
+    schema-return-type-qualified-fn "the docstring"
+    schema-return-type-vector-fn "the docstring"
+    reader-conditional-fn "Returns a language-appropriate error"))
 
 (deftest inline-comments
   (testing "inline comments ignored by default"


### PR DESCRIPTION
As it always goes, I did a little bit of work and then kept tinkering and ended up touching probably too many things.

* Switched markdown parsers to [flexmark-java](https://github.com/vsch/flexmark-java), a fast and conforming markdown parser and renderer that has a ton of knobs for adjusting behavior or extensions. This comes built-in with support for code blocks.
* Added support for `defmethod` docstrings, which are technically legal.
* Change `slurp-resource` to use `io/resource`.
* Clean up the parsing tests.
* Remove non-functioning css for `<tr>`.
* Clean up `source-excluded` to do less work.
* Update tools.cli to 1.4.256.
* Update tools.namespace to 1.5.1.

Closes #199